### PR TITLE
fix(pocket): update model paths and add BOS support for multilingual …

### DIFF
--- a/app/src/main/java/com/nekospeak/tts/NekoTtsService.kt
+++ b/app/src/main/java/com/nekospeak/tts/NekoTtsService.kt
@@ -38,7 +38,7 @@ class NekoTtsService : TextToSpeechService() {
     
     companion object {
         private const val TAG = "NekoTtsService"
-        private const val INIT_TIMEOUT_MS = 5000L  // 5 seconds max wait for engine init
+        private const val INIT_TIMEOUT_MS = 30000L  // 30 seconds max wait for engine init (pocket_v1 takes ~12s cold)
     }
     
     private val exceptionHandler = kotlinx.coroutines.CoroutineExceptionHandler { _, throwable ->
@@ -133,9 +133,13 @@ class NekoTtsService : TextToSpeechService() {
                     null
                 }
             } catch (t: Throwable) {
-                Log.e(TAG, "CRITICAL: InitJob crashed", t)
-                SupportLogStore.log(applicationContext, TAG, "Engine initialization crashed", t)
-                // Don't swap on exception either
+                if (t is kotlinx.coroutines.CancellationException) {
+                    Log.d(TAG, "Engine initialization cancelled")
+                    SupportLogStore.log(applicationContext, TAG, "Engine initialization cancelled")
+                } else {
+                    Log.e(TAG, "CRITICAL: InitJob crashed", t)
+                    SupportLogStore.log(applicationContext, TAG, "Engine initialization crashed", t)
+                }
                 null
             }
         }

--- a/app/src/main/java/com/nekospeak/tts/data/ModelRepository.kt
+++ b/app/src/main/java/com/nekospeak/tts/data/ModelRepository.kt
@@ -30,33 +30,34 @@ object ModelRepository {
     private const val TAG = "ModelRepository"
     
     // URLs from KevinAHM's HuggingFace space and official tts-voices
-    // Note: mimi_encoder and text_conditioner are FP32 only, others have INT8
     private const val HF_BASE = "https://huggingface.co/spaces/KevinAHM/pocket-tts-web/resolve/main"
+    private const val BUNDLE = "onnx/english_2026-04"
     private const val VOICES_BASE = "https://huggingface.co/kyutai/tts-voices/resolve/main"
-    
+
     val models = listOf(
         ModelInfo(
             id = "pocket_v1",
             name = "Pocket-TTS (Experimental)",
             description = "Required for voice cloning. Includes encoder, decoder, and flow matching models (~200MB total).",
             files = listOf(
-                // ONNX Models - use correct filenames from HuggingFace
-                ModelFile("pocket/models/mimi_encoder.onnx", "$HF_BASE/onnx/mimi_encoder.onnx", "Mimi Encoder (73MB)"),
-                ModelFile("pocket/models/text_conditioner.onnx", "$HF_BASE/onnx/text_conditioner.onnx", "Text Conditioner (16MB)"),
-                ModelFile("pocket/models/flow_lm_main_int8.onnx", "$HF_BASE/onnx/flow_lm_main_int8.onnx", "Flow LM Main INT8 (76MB)"),
-                ModelFile("pocket/models/flow_lm_flow_int8.onnx", "$HF_BASE/onnx/flow_lm_flow_int8.onnx", "Flow LM Flow INT8 (10MB)"),
-                ModelFile("pocket/models/mimi_decoder_int8.onnx", "$HF_BASE/onnx/mimi_decoder_int8.onnx", "Mimi Decoder INT8 (23MB)"),
-                // Tokenizer
-                ModelFile("pocket/tokenizer.model", "$HF_BASE/tokenizer.model", "Tokenizer (59KB)"),
+                // ONNX Models — all now in per-language bundle subdirectory; encoder and conditioner now INT8
+                ModelFile("pocket/models/mimi_encoder_int8.onnx",    "$HF_BASE/$BUNDLE/mimi_encoder_int8.onnx",    "Mimi Encoder INT8 (73MB)"),
+                ModelFile("pocket/models/text_conditioner_int8.onnx","$HF_BASE/$BUNDLE/text_conditioner_int8.onnx","Text Conditioner INT8 (16MB)"),
+                ModelFile("pocket/models/flow_lm_main_int8.onnx",    "$HF_BASE/$BUNDLE/flow_lm_main_int8.onnx",    "Flow LM Main INT8 (76MB)"),
+                ModelFile("pocket/models/flow_lm_flow_int8.onnx",    "$HF_BASE/$BUNDLE/flow_lm_flow_int8.onnx",    "Flow LM Flow INT8 (10MB)"),
+                ModelFile("pocket/models/mimi_decoder_int8.onnx",    "$HF_BASE/$BUNDLE/mimi_decoder_int8.onnx",    "Mimi Decoder INT8 (23MB)"),
+                // Tokenizer and BOS conditioning — now per-language bundle
+                ModelFile("pocket/tokenizer.model",      "$HF_BASE/$BUNDLE/tokenizer.model",      "Tokenizer (59KB)"),
+                ModelFile("pocket/bos_before_voice.npy", "$HF_BASE/$BUNDLE/bos_before_voice.npy", "Voice BOS embedding"),
                 // Voice WAV files from official kyutai/tts-voices (encoded at runtime via mimi_encoder)
-                ModelFile("pocket/voices/alba.wav", "$VOICES_BASE/alba-mackenna/casual.wav", "Alba Voice"),
-                ModelFile("pocket/voices/marius.wav", "$VOICES_BASE/voice-donations/Selfie.wav", "Marius Voice"),
-                ModelFile("pocket/voices/javert.wav", "$VOICES_BASE/voice-donations/Butter.wav", "Javert Voice"),
-                ModelFile("pocket/voices/jean.wav", "$VOICES_BASE/ears/p010/freeform_speech_01.wav", "Jean Voice"),
-                ModelFile("pocket/voices/fantine.wav", "$VOICES_BASE/vctk/p244_023.wav", "Fantine Voice"),
-                ModelFile("pocket/voices/cosette.wav", "$VOICES_BASE/expresso/ex04-ex02_confused_001_channel1_499s.wav", "Cosette Voice"),
-                ModelFile("pocket/voices/eponine.wav", "$VOICES_BASE/vctk/p262_023.wav", "Eponine Voice"),
-                ModelFile("pocket/voices/azelma.wav", "$VOICES_BASE/vctk/p303_023.wav", "Azelma Voice")
+                ModelFile("pocket/voices/alba.wav",    "$VOICES_BASE/alba-mackenna/casual.wav",                        "Alba Voice"),
+                ModelFile("pocket/voices/marius.wav",  "$VOICES_BASE/voice-donations/Selfie.wav",                     "Marius Voice"),
+                ModelFile("pocket/voices/javert.wav",  "$VOICES_BASE/voice-donations/Butter.wav",                     "Javert Voice"),
+                ModelFile("pocket/voices/jean.wav",    "$VOICES_BASE/ears/p010/freeform_speech_01.wav",               "Jean Voice"),
+                ModelFile("pocket/voices/fantine.wav", "$VOICES_BASE/vctk/p244_023.wav",                              "Fantine Voice"),
+                ModelFile("pocket/voices/cosette.wav", "$VOICES_BASE/expresso/ex04-ex02_confused_001_channel1_499s.wav","Cosette Voice"),
+                ModelFile("pocket/voices/eponine.wav", "$VOICES_BASE/vctk/p262_023.wav",                              "Eponine Voice"),
+                ModelFile("pocket/voices/azelma.wav",  "$VOICES_BASE/vctk/p303_023.wav",                              "Azelma Voice")
             )
         ),
         ModelInfo(

--- a/app/src/main/java/com/nekospeak/tts/data/PrefsManager.kt
+++ b/app/src/main/java/com/nekospeak/tts/data/PrefsManager.kt
@@ -77,7 +77,7 @@ class PrefsManager(context: Context) {
         set(value) = prefs.edit().putFloat(KEY_POCKET_TEMP, value).apply()
     
     var pocketLsdSteps: Int
-        get() = prefs.getInt(KEY_POCKET_LSD, 10)
+        get() = prefs.getInt(KEY_POCKET_LSD, 6)
         set(value) = prefs.edit().putInt(KEY_POCKET_LSD, value).apply()
     
     var pocketFramesAfterEos: Int
@@ -85,7 +85,7 @@ class PrefsManager(context: Context) {
         set(value) = prefs.edit().putInt(KEY_POCKET_EOS, value).apply()
     
     var pocketDecodingMode: String
-        get() = prefs.getString(KEY_POCKET_DECODE, "batch") ?: "batch"
+        get() = prefs.getString(KEY_POCKET_DECODE, "streaming") ?: "streaming"
         set(value) = prefs.edit().putString(KEY_POCKET_DECODE, value).apply()
     
     var pocketDecodeChunkSize: Int

--- a/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTtsEngine.kt
+++ b/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTtsEngine.kt
@@ -40,6 +40,7 @@ class PocketTtsEngine(
         const val LATENT_DIM = 32
         const val EMBED_DIM = 1024
         const val ODE_STEPS = 20  // More steps = better quality (default: 10, max: 50)
+        private const val KV_CACHE_WINDOW = 40 // Keep last 40 frames (~3.2s); prevents O(n) inference growth
         
         // Model paths (relative to filesDir/pocket/models/)
         private const val MODELS_DIR = "pocket/models"
@@ -86,6 +87,8 @@ class PocketTtsEngine(
     // Flow LM state (for autoregressive generation) - map of state name to tensor data
     // Each entry has: name -> Pair(type: String, data: Any) where data is FloatArray or LongArray
     private var flowLmState: MutableMap<String, Pair<String, Any>>? = null
+    // Static shapes from model spec (may contain -1 for dynamic dims); used for KV cache windowing
+    private var flowLmStateShapes: MutableMap<String, LongArray>? = null
     
     // Pre-computed flow buffers for Euler integration (s/t time steps)
     // Computed once per lsdSteps value to avoid repeated allocation
@@ -1450,7 +1453,9 @@ class PocketTtsEngine(
                             FloatArray(buf.remaining()).also { buf.get(it) }
                         }
                     }
-                    flowLmState!![stateName] = Pair(typeAndData.first, newData)
+                    val staticShape = flowLmStateShapes?.get(stateName)
+                    val windowedData = if (staticShape != null) truncateKvCache(newData, staticShape, KV_CACHE_WINDOW) else newData
+                    flowLmState!![stateName] = Pair(typeAndData.first, windowedData)
                 }
             }
             
@@ -1555,7 +1560,8 @@ class PocketTtsEngine(
         val session = flowLmMain ?: return
         
         val stateMap = mutableMapOf<String, Pair<String, Any>>()
-        
+        val shapeMap = mutableMapOf<String, LongArray>()
+
         session.inputInfo.forEach { (name, info) ->
             if (name.startsWith("state_")) {
                 val tensorInfo = info.info as? ai.onnxruntime.TensorInfo ?: return@forEach
@@ -1564,21 +1570,23 @@ class PocketTtsEngine(
                 // The model grows these during autoregressive generation
                 val size = shape.fold(1L) { acc, dim -> acc * if (dim < 0) 0 else dim }.toInt().coerceAtLeast(0)
                 val type = tensorInfo.type.toString()
-                
+
                 Log.d(TAG, "State $name: type=$type, shape=${shape.contentToString()}, size=$size")
-                
+
                 val data: Any = when {
                     type.contains("int64", ignoreCase = true) -> LongArray(size) { 0L }
                     type.contains("bool", ignoreCase = true) -> LongArray(size) { 0L }
                     else -> FloatArray(size) { 0f }
                 }
-                
+
                 stateMap[name] = Pair(type, data)
+                shapeMap[name] = shape
             }
         }
-        
+
         Log.d(TAG, "Initialized ${stateMap.size} flow LM states")
         flowLmState = stateMap
+        flowLmStateShapes = shapeMap
     }
     
     private fun updateFlowLmState(latent: FloatArray) {
@@ -1587,6 +1595,40 @@ class PocketTtsEngine(
     
     private fun resetFlowLmState() {
         flowLmState = null
+        flowLmStateShapes = null
+    }
+
+    /**
+     * Truncate KV cache state along its dynamic (sequence) dimension to at most [maxFrames].
+     * Handles any position of the dynamic dim: treats all dims before it as batch and all dims
+     * after it as frame stride, then copies the last [maxFrames] slices for each batch entry.
+     */
+    private fun truncateKvCache(data: Any, staticShape: LongArray, maxFrames: Int): Any {
+        val dynIdx = staticShape.indexOfFirst { it < 0 }
+        if (dynIdx < 0) return data
+
+        val batchCount = staticShape.take(dynIdx).fold(1L) { acc, d -> acc * d }.toInt()
+        val frameStride = staticShape.drop(dynIdx + 1).fold(1L) { acc, d -> acc * d }.toInt()
+        val totalPerBatch = batchCount * frameStride
+
+        fun <T> truncate(src: T, size: Int, newArray: (Int) -> T, copyRange: (T, Int, T, Int, Int) -> Unit): T {
+            val numFrames = size / totalPerBatch
+            if (numFrames <= maxFrames) return src
+            val skipFrames = numFrames - maxFrames
+            val dst = newArray(batchCount * maxFrames * frameStride)
+            for (b in 0 until batchCount) {
+                val srcStart = b * numFrames * frameStride + skipFrames * frameStride
+                val dstStart = b * maxFrames * frameStride
+                copyRange(src, srcStart, dst, dstStart, maxFrames * frameStride)
+            }
+            return dst
+        }
+
+        return when (data) {
+            is FloatArray -> truncate(data, data.size, ::FloatArray) { s, si, d, di, n -> System.arraycopy(s, si, d, di, n) }
+            is LongArray  -> truncate(data, data.size, ::LongArray)  { s, si, d, di, n -> System.arraycopy(s, si, d, di, n) }
+            else -> data
+        }
     }
     
     /**

--- a/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTtsEngine.kt
+++ b/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTtsEngine.kt
@@ -42,13 +42,14 @@ class PocketTtsEngine(
         const val ODE_STEPS = 20  // More steps = better quality (default: 10, max: 50)
         
         // Model paths (relative to filesDir/pocket/models/)
-        // Note: mimi_encoder and text_conditioner are FP32 only (no INT8 version available)
         private const val MODELS_DIR = "pocket/models"
-        private const val MODEL_MIMI_ENCODER = "mimi_encoder.onnx"
-        private const val MODEL_TEXT_CONDITIONER = "text_conditioner.onnx"
-        private const val MODEL_FLOW_LM_MAIN = "flow_lm_main_int8.onnx"
-        private const val MODEL_FLOW_LM_FLOW = "flow_lm_flow_int8.onnx"
-        private const val MODEL_MIMI_DECODER = "mimi_decoder_int8.onnx"
+        private const val MODEL_MIMI_ENCODER     = "mimi_encoder_int8.onnx"
+        private const val MODEL_TEXT_CONDITIONER = "text_conditioner_int8.onnx"
+        private const val MODEL_FLOW_LM_MAIN     = "flow_lm_main_int8.onnx"
+        private const val MODEL_FLOW_LM_FLOW     = "flow_lm_flow_int8.onnx"
+        private const val MODEL_MIMI_DECODER     = "mimi_decoder_int8.onnx"
+
+        private const val BOS_BEFORE_VOICE_PATH = "pocket/bos_before_voice.npy"
         
         // Bundled voices path
         private const val BUNDLED_VOICES_DIR = "pocket/voices"
@@ -67,6 +68,11 @@ class PocketTtsEngine(
     private var mimiCodec: MimiCodec? = null
     private var tokenizer: PocketTokenizer? = null
     private var gtcrnDenoiser: GtcrnDenoiser? = null
+
+    // Pre-computed BOS embedding prepended to voice embeddings before voice conditioning pass.
+    // Required by the multilingual v2 bundle (bundle.json: insert_bos_before_voice = true).
+    private var bosEmbedding: FloatArray? = null
+    private var bosFrames: Int = 0
     
     private val voiceStates = mutableMapOf<String, PocketVoiceState>()
     private var currentVoice: String = "alba"
@@ -222,6 +228,9 @@ class PocketTtsEngine(
                     gtcrnDenoiser?.initialize()
                 }
                 
+                // Load BOS-before-voice embedding (required by multilingual v2 bundle)
+                loadBosBeforeVoice()
+
                 // Load available voices
                 loadBundledVoices()
                 loadClonedVoices()
@@ -282,6 +291,59 @@ class PocketTtsEngine(
         }
     }
     
+    private fun loadBosBeforeVoice() {
+        val file = File(context.filesDir, BOS_BEFORE_VOICE_PATH)
+        if (!file.exists()) {
+            Log.w(TAG, "bos_before_voice.npy not found — voice conditioning BOS token will be skipped")
+            return
+        }
+        val result = parseNpyFloat32(file.readBytes())
+        if (result == null) {
+            Log.e(TAG, "Failed to parse bos_before_voice.npy")
+            return
+        }
+        val (data, shape) = result
+        // Shape is (1, B, EMBED_DIM); B is the number of BOS frames (typically 1)
+        bosFrames = if (shape.size >= 2) shape[shape.size - 2] else 1
+        bosEmbedding = data
+        Log.i(TAG, "Loaded bos_before_voice: $bosFrames frame(s), ${data.size} floats")
+    }
+
+    private fun parseNpyFloat32(bytes: ByteArray): Pair<FloatArray, IntArray>? {
+        if (bytes.size < 10) return null
+        val expected = byteArrayOf(0x93.toByte(), 'N'.code.toByte(), 'U'.code.toByte(),
+                                   'M'.code.toByte(), 'P'.code.toByte(), 'Y'.code.toByte())
+        for (i in expected.indices) {
+            if (bytes[i] != expected[i]) {
+                Log.e(TAG, "Invalid NPY magic bytes")
+                return null
+            }
+        }
+        val major = bytes[6].toInt() and 0xFF
+        val headerLen: Int
+        val headerOffset: Int
+        if (major == 1) {
+            headerLen = ((bytes[9].toInt() and 0xFF) shl 8) or (bytes[8].toInt() and 0xFF)
+            headerOffset = 10
+        } else {
+            headerLen = ((bytes[11].toInt() and 0xFF) shl 24) or ((bytes[10].toInt() and 0xFF) shl 16) or
+                        ((bytes[9].toInt()  and 0xFF) shl 8)  or (bytes[8].toInt()  and 0xFF)
+            headerOffset = 12
+        }
+        val header = String(bytes, headerOffset, headerLen, Charsets.US_ASCII)
+        val shapeMatch = Regex("'shape':\\s*\\(([^)]*)\\)").find(header)
+            ?: return null
+        val shape = shapeMatch.groupValues[1].split(",")
+            .map { it.trim() }.filter { it.isNotEmpty() }
+            .map { it.toInt() }.toIntArray()
+        val dataOffset = headerOffset + headerLen
+        val numFloats = (bytes.size - dataOffset) / 4
+        val buf = java.nio.ByteBuffer.wrap(bytes, dataOffset, bytes.size - dataOffset)
+            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+        val data = FloatArray(numFloats) { buf.float }
+        return Pair(data, shape)
+    }
+
     // Voice embeddings cache: voiceId -> FloatArray of shape [N * 1024] flattened
     private val voiceEmbeddings = mutableMapOf<String, FloatArray>()
     private val voiceEmbeddingFrames = mutableMapOf<String, Int>()
@@ -1000,14 +1062,25 @@ class PocketTtsEngine(
             val numTextTokens = tokens.size
             
             // Voice embeddings from voice state [numFrames, 1024]
-            val voiceEmbeddings = voiceState.latents
-            val numVoiceFrames = voiceState.numFrames
-            
+            // Prepend bos_before_voice embedding when available (required by multilingual v2 bundle).
+            val (voiceEmbeddings, numVoiceFrames) = run {
+                val bos = bosEmbedding
+                if (bos != null && bosFrames > 0) {
+                    val raw = voiceState.latents
+                    val combined = FloatArray(bos.size + raw.size)
+                    bos.copyInto(combined)
+                    raw.copyInto(combined, bos.size)
+                    Pair(combined, voiceState.numFrames + bosFrames)
+                } else {
+                    Pair(voiceState.latents, voiceState.numFrames)
+                }
+            }
+
             // Empty tensors for conditioning passes
             val emptySeq = FloatArray(0) // [1, 0, 32]
             val emptyText = FloatArray(0) // [1, 0, 1024]
-            
-            // PASS 1: Voice conditioning - empty sequence, voice embeddings
+
+            // PASS 1: Voice conditioning - empty sequence, voice embeddings (with BOS prepended)
             Log.d(TAG, "Pass 1: Voice conditioning ($numVoiceFrames frames)")
             runFlowLmMainPass(session, emptySeq, 0, voiceEmbeddings, numVoiceFrames)
             


### PR DESCRIPTION
…v2 bundle

pocket-tts-web commit d0c0c79 moved all models from a flat onnx/ layout into per-language bundles (onnx/english_2026-04/). Download URLs and local filenames for mimi_encoder and text_conditioner also changed from FP32 to INT8 variants. The new bundle additionally requires a bos_before_voice.npy embedding prepended to voice embeddings before the voice conditioning pass.

- Update all five ONNX model download URLs to the english_2026-04 bundle path
- Rename mimi_encoder/text_conditioner local files and constants to _int8 suffix
- Move tokenizer.model download URL into the bundle subdirectory
- Download bos_before_voice.npy as part of the model set
- Add NPY float32 parser and loadBosBeforeVoice() to PocketTtsEngine
- Prepend BOS embedding to voice embeddings in Pass 1 of generate()

Existing installs will re-download automatically (old filenames no longer match).