### PR TITLE
fix: update HuggingFace URL and add external storage sideload fallback for Pocket-TTS

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,35 @@
+name: Build Android APK
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NekoSpeak-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -16,11 +16,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -32,4 +31,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: NekoSpeak-debug-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: app/build/outputs/apk/**/*.apk

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ The first and foremost consideration was **fully offline functionality** - no in
 | Kitten TTS | Nano | ~23MB | Fair | 📥 On-demand |
 | Piper | Community Voices | Varies | Varies | 📥 100+ downloadable voices |
 
+### 📂 Manual Model Sideloading (Offline Installation)
+
+If you have restricted internet access or prefer loading models completely offline:
+1. Download the Pocket-TTS ONNX model files and `tokenizer.model` (from [HuggingFace](https://huggingface.co/KevinAHM/pocket-tts-onnx)).
+2. Place the model files in your device's app-specific external storage folder:
+   `/sdcard/Android/data/com.nekospeak.tts/files/` (or `/sdcard/Android/data/com.nekospeak.tts/files/pocket/`)
+3. The app will automatically detect external storage models and mark Pocket-TTS as **Installed** without requiring an in-app download.
+
+
 ## 📸 Screenshots
 
 | Onboarding | Voice Selection | Settings |

--- a/TECHNICAL_DEEP_DIVE.md
+++ b/TECHNICAL_DEEP_DIVE.md
@@ -340,6 +340,16 @@ sequenceDiagram
     Svc->>UI: Playback
 ```
 
+### 3.5. Model Storage & Sideloading Fallback
+
+To support offline-first usage and manual model sideloading without in-app downloads, `ModelRepository.kt` and `PocketTtsEngine.kt` implement an external storage resolution chain:
+
+1. **Internal Storage Check**: `context.filesDir` (e.g. `/data/user/0/com.nekospeak.tts/files/pocket/`)
+2. **External Storage Fallback**: `context.getExternalFilesDir(null)` (e.g. `/sdcard/Android/data/com.nekospeak.tts/files/pocket/`)
+3. **Quantization Alias Fallback**: Checks for both standard (`.onnx`) and quantized (`_int8.onnx`) filenames.
+
+If valid ONNX model files ($> 1\text{ KB}$) are found in external storage, `ModelRepository.isInstalled()` resolves them as valid, allowing the engine to initialize ONNX sessions directly from external storage paths.
+
 ---
 
 ## 4. Kokoro & Kitten Engine

--- a/app/src/main/java/com/nekospeak/tts/data/ModelRepository.kt
+++ b/app/src/main/java/com/nekospeak/tts/data/ModelRepository.kt
@@ -29,9 +29,9 @@ data class ModelInfo(
 object ModelRepository {
     private const val TAG = "ModelRepository"
     
-    // URLs from KevinAHM's HuggingFace space and official tts-voices
+    // URLs from KevinAHM's HuggingFace repository and official tts-voices
     // Note: mimi_encoder and text_conditioner are FP32 only, others have INT8
-    private const val HF_BASE = "https://huggingface.co/spaces/KevinAHM/pocket-tts-web/resolve/main"
+    private const val HF_BASE = "https://huggingface.co/KevinAHM/pocket-tts-onnx/resolve/main"
     private const val VOICES_BASE = "https://huggingface.co/kyutai/tts-voices/resolve/main"
     
     val models = listOf(
@@ -86,11 +86,39 @@ object ModelRepository {
         return _downloadStates[modelId]?.asStateFlow()
     }
 
+    fun getModelFile(context: Context, fileName: String): File {
+        val internalFile = File(context.filesDir, fileName)
+        if (internalFile.exists() && internalFile.length() > 1024) {
+            return internalFile
+        }
+        val externalDir = context.getExternalFilesDir(null)
+        if (externalDir != null) {
+            val externalFile = File(externalDir, fileName)
+            if (externalFile.exists() && externalFile.length() > 1024) {
+                return externalFile
+            }
+            if (fileName.endsWith("_int8.onnx")) {
+                val altName = fileName.replace("_int8.onnx", ".onnx")
+                val altExternalFile = File(externalDir, altName)
+                if (altExternalFile.exists() && altExternalFile.length() > 1024) {
+                    return altExternalFile
+                }
+            }
+        }
+        if (fileName.endsWith("_int8.onnx")) {
+            val altName = fileName.replace("_int8.onnx", ".onnx")
+            val altInternalFile = File(context.filesDir, altName)
+            if (altInternalFile.exists() && altInternalFile.length() > 1024) {
+                return altInternalFile
+            }
+        }
+        return internalFile
+    }
+
     fun isInstalled(context: Context, modelId: String): Boolean {
         val model = models.find { it.id == modelId } ?: return false
         return model.files.all { fileDef ->
-            val file = File(context.filesDir, fileDef.fileName)
-            // Check file exists and has reasonable size (> 1KB to avoid placeholder files)
+            val file = getModelFile(context, fileDef.fileName)
             file.exists() && file.length() > 1024
         }
     }

--- a/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTokenizer.kt
+++ b/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTokenizer.kt
@@ -45,7 +45,16 @@ class PocketTokenizer(private val context: Context) {
      * Load and parse the SentencePiece model file.
      */
     fun load() {
-        val tokenizerFile = File(context.filesDir, TOKENIZER_MODEL)
+        var tokenizerFile = File(context.filesDir, TOKENIZER_MODEL)
+        if (!tokenizerFile.exists()) {
+            val externalDir = context.getExternalFilesDir(null)
+            if (externalDir != null) {
+                val extFile = File(externalDir, TOKENIZER_MODEL)
+                if (extFile.exists() && extFile.length() > 0) {
+                    tokenizerFile = extFile
+                }
+            }
+        }
         
         if (!tokenizerFile.exists()) {
             Log.e(TAG, "Tokenizer model not found: ${tokenizerFile.absolutePath}")

--- a/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTtsEngine.kt
+++ b/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTtsEngine.kt
@@ -176,7 +176,6 @@ class PocketTtsEngine(
                 return@withContext false
             }
             
-            // Check required model files first
             val modelFiles = if (cloneOnly) {
                 listOf(MODEL_MIMI_ENCODER)
             } else {
@@ -190,9 +189,9 @@ class PocketTtsEngine(
             }
             
             for (model in modelFiles) {
-                val modelFile = File(modelsDir, model)
-                if (!modelFile.exists()) {
-                    Log.w(TAG, "Model not found: $model. Download required.")
+                val modelFile = resolveModelFile(context, "$MODELS_DIR/$model")
+                if (!modelFile.exists() || modelFile.length() <= 1024) {
+                    Log.w(TAG, "Model not found or invalid: $model. Download required.")
                     return@withContext false
                 }
             }
@@ -201,12 +200,12 @@ class PocketTtsEngine(
             val sessionOptions = createSessionOptions()
             
             Log.d(TAG, "Loading ONNX models...")
-            mimiEncoder = loadModel(modelsDir, MODEL_MIMI_ENCODER, sessionOptions)
+            mimiEncoder = loadModel(context, "$MODELS_DIR/$MODEL_MIMI_ENCODER", sessionOptions)
             if (!cloneOnly) {
-                textConditioner = loadModel(modelsDir, MODEL_TEXT_CONDITIONER, sessionOptions)
-                flowLmMain = loadModel(modelsDir, MODEL_FLOW_LM_MAIN, sessionOptions)
-                flowLmFlow = loadModel(modelsDir, MODEL_FLOW_LM_FLOW, sessionOptions)
-                mimiDecoder = loadModel(modelsDir, MODEL_MIMI_DECODER, sessionOptions)
+                textConditioner = loadModel(context, "$MODELS_DIR/$MODEL_TEXT_CONDITIONER", sessionOptions)
+                flowLmMain = loadModel(context, "$MODELS_DIR/$MODEL_FLOW_LM_MAIN", sessionOptions)
+                flowLmFlow = loadModel(context, "$MODELS_DIR/$MODEL_FLOW_LM_FLOW", sessionOptions)
+                mimiDecoder = loadModel(context, "$MODELS_DIR/$MODEL_MIMI_DECODER", sessionOptions)
                 
                 // Initialize codec
                 mimiCodec = MimiCodec(mimiEncoder!!, mimiDecoder!!, ortEnv!!)
@@ -238,6 +237,31 @@ class PocketTtsEngine(
         }
     }
     
+    private fun resolveModelFile(context: Context, relativePath: String): File {
+        val internalFile = File(context.filesDir, relativePath)
+        if (internalFile.exists() && internalFile.length() > 1024) return internalFile
+        
+        val externalDir = context.getExternalFilesDir(null)
+        if (externalDir != null) {
+            val externalFile = File(externalDir, relativePath)
+            if (externalFile.exists() && externalFile.length() > 1024) return externalFile
+            
+            if (relativePath.endsWith("_int8.onnx")) {
+                val altName = relativePath.replace("_int8.onnx", ".onnx")
+                val altExternalFile = File(externalDir, altName)
+                if (altExternalFile.exists() && altExternalFile.length() > 1024) return altExternalFile
+            }
+        }
+        
+        if (relativePath.endsWith("_int8.onnx")) {
+            val altName = relativePath.replace("_int8.onnx", ".onnx")
+            val altInternalFile = File(context.filesDir, altName)
+            if (altInternalFile.exists() && altInternalFile.length() > 1024) return altInternalFile
+        }
+        
+        return internalFile
+    }
+    
     private fun createSessionOptions(): OrtSession.SessionOptions {
         val prefs = com.nekospeak.tts.data.PrefsManager(context)
         return OrtSession.SessionOptions().apply {
@@ -266,8 +290,8 @@ class PocketTtsEngine(
      * 
      * On 64-bit (arm64-v8a, x86_64): Uses efficient mmap-based file path loading.
      */
-    private fun loadModel(dir: File, name: String, options: OrtSession.SessionOptions): OrtSession {
-        val modelFile = File(dir, name)
+    private fun loadModel(context: Context, relativePath: String, options: OrtSession.SessionOptions): OrtSession {
+        val modelFile = resolveModelFile(context, relativePath)
         val sizeInMB = modelFile.length() / 1024 / 1024
         Log.d(TAG, "Loading model: ${modelFile.absolutePath} (${sizeInMB}MB)")
         


### PR DESCRIPTION
## Description
- **Fixed broken HuggingFace URL**: Updated  in `ModelRepository.kt` from `spaces/KevinAHM/pocket-tts-web` (which returns 404) to `KevinAHM/pocket-tts-onnx/resolve/main` (valid repository).
- **External Storage Sideloading**: Added fallback resolution in `ModelRepository.kt`, `PocketTtsEngine.kt`, and `PocketTokenizer.kt` to check `getExternalFilesDir(null)` (`/sdcard/Android/data/com.nekospeak.tts/files/pocket/`) if models aren't in internal storage.
- **Name Fallback**: Added fallback resolution so both `_int8.onnx` and standard `.onnx` model files are resolved correctly.