### PR TITLE
fix(pocket): point downloads at onnx/english_2026-04 bundle on correct HF repo

### DIFF
--- a/app/src/main/java/com/nekospeak/tts/NekoTtsService.kt
+++ b/app/src/main/java/com/nekospeak/tts/NekoTtsService.kt
@@ -38,7 +38,7 @@ class NekoTtsService : TextToSpeechService() {
     
     companion object {
         private const val TAG = "NekoTtsService"
-        private const val INIT_TIMEOUT_MS = 5000L  // 5 seconds max wait for engine init
+        private const val INIT_TIMEOUT_MS = 30000L  // 30s max wait for engine init (pocket_v1 cold init ~12s)
     }
     
     private val exceptionHandler = kotlinx.coroutines.CoroutineExceptionHandler { _, throwable ->

--- a/app/src/main/java/com/nekospeak/tts/data/ModelRepository.kt
+++ b/app/src/main/java/com/nekospeak/tts/data/ModelRepository.kt
@@ -29,9 +29,10 @@ data class ModelInfo(
 object ModelRepository {
     private const val TAG = "ModelRepository"
     
-    // URLs from KevinAHM's HuggingFace space and official tts-voices
-    // Note: mimi_encoder and text_conditioner are FP32 only, others have INT8
-    private const val HF_BASE = "https://huggingface.co/spaces/KevinAHM/pocket-tts-web/resolve/main"
+    // URLs from KevinAHM's pocket-tts-onnx HF repo (per-language bundles) and official tts-voices
+    // Note: all five ONNX models available as INT8 in the bundle
+    private const val HF_BASE = "https://huggingface.co/KevinAHM/pocket-tts-onnx/resolve/main"
+    private const val BUNDLE = "onnx/english_2026-04"
     private const val VOICES_BASE = "https://huggingface.co/kyutai/tts-voices/resolve/main"
     
     val models = listOf(
@@ -41,13 +42,14 @@ object ModelRepository {
             description = "Required for voice cloning. Includes encoder, decoder, and flow matching models (~200MB total).",
             files = listOf(
                 // ONNX Models - use correct filenames from HuggingFace
-                ModelFile("pocket/models/mimi_encoder.onnx", "$HF_BASE/onnx/mimi_encoder.onnx", "Mimi Encoder (73MB)"),
-                ModelFile("pocket/models/text_conditioner.onnx", "$HF_BASE/onnx/text_conditioner.onnx", "Text Conditioner (16MB)"),
-                ModelFile("pocket/models/flow_lm_main_int8.onnx", "$HF_BASE/onnx/flow_lm_main_int8.onnx", "Flow LM Main INT8 (76MB)"),
-                ModelFile("pocket/models/flow_lm_flow_int8.onnx", "$HF_BASE/onnx/flow_lm_flow_int8.onnx", "Flow LM Flow INT8 (10MB)"),
-                ModelFile("pocket/models/mimi_decoder_int8.onnx", "$HF_BASE/onnx/mimi_decoder_int8.onnx", "Mimi Decoder INT8 (23MB)"),
+                ModelFile("pocket/models/mimi_encoder_int8.onnx", "$HF_BASE/$BUNDLE/mimi_encoder_int8.onnx", "Mimi Encoder INT8 (21MB)"),
+                ModelFile("pocket/models/text_conditioner_int8.onnx", "$HF_BASE/$BUNDLE/text_conditioner_int8.onnx", "Text Conditioner INT8 (16MB)"),
+                ModelFile("pocket/models/flow_lm_main_int8.onnx", "$HF_BASE/$BUNDLE/flow_lm_main_int8.onnx", "Flow LM Main INT8 (76MB)"),
+                ModelFile("pocket/models/flow_lm_flow_int8.onnx", "$HF_BASE/$BUNDLE/flow_lm_flow_int8.onnx", "Flow LM Flow INT8 (10MB)"),
+                ModelFile("pocket/models/mimi_decoder_int8.onnx", "$HF_BASE/$BUNDLE/mimi_decoder_int8.onnx", "Mimi Decoder INT8 (23MB)"),
                 // Tokenizer
-                ModelFile("pocket/tokenizer.model", "$HF_BASE/tokenizer.model", "Tokenizer (59KB)"),
+                ModelFile("pocket/tokenizer.model", "$HF_BASE/$BUNDLE/tokenizer.model", "Tokenizer (59KB)"),
+                ModelFile("pocket/bos_before_voice.npy", "$HF_BASE/$BUNDLE/bos_before_voice.npy", "Voice BOS embedding"),
                 // Voice WAV files from official kyutai/tts-voices (encoded at runtime via mimi_encoder)
                 ModelFile("pocket/voices/alba.wav", "$VOICES_BASE/alba-mackenna/casual.wav", "Alba Voice"),
                 ModelFile("pocket/voices/marius.wav", "$VOICES_BASE/voice-donations/Selfie.wav", "Marius Voice"),

--- a/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTtsEngine.kt
+++ b/app/src/main/java/com/nekospeak/tts/engine/pocket/PocketTtsEngine.kt
@@ -42,10 +42,10 @@ class PocketTtsEngine(
         const val ODE_STEPS = 20  // More steps = better quality (default: 10, max: 50)
         
         // Model paths (relative to filesDir/pocket/models/)
-        // Note: mimi_encoder and text_conditioner are FP32 only (no INT8 version available)
+        // Note: all models loaded from INT8 bundle files (mimi_encoder/text_conditioner INT8 verified in onnx/english_2026-04)
         private const val MODELS_DIR = "pocket/models"
-        private const val MODEL_MIMI_ENCODER = "mimi_encoder.onnx"
-        private const val MODEL_TEXT_CONDITIONER = "text_conditioner.onnx"
+        private const val MODEL_MIMI_ENCODER = "mimi_encoder_int8.onnx"
+        private const val MODEL_TEXT_CONDITIONER = "text_conditioner_int8.onnx"
         private const val MODEL_FLOW_LM_MAIN = "flow_lm_main_int8.onnx"
         private const val MODEL_FLOW_LM_FLOW = "flow_lm_flow_int8.onnx"
         private const val MODEL_MIMI_DECODER = "mimi_decoder_int8.onnx"


### PR DESCRIPTION
## Summary

Pocket-TTS downloads are completely broken in v1.4.x and on current `fix/all-github-issues` (the branch the v1.5.0 release APK was cut from): every model request 404s or the batch stalls at ~80% (#12, #15, #24, #25, and the download failures reported in #13, #14, #20). Root cause is the hardcoded base URL pointing at a HuggingFace *Space* that no longer serves the files, plus the models having moved into a per-language bundle layout.

This PR:

- Repoints `HF_BASE` from the dead `spaces/KevinAHM/pocket-tts-web` URL to the live `KevinAHM/pocket-tts-onnx` model repo
- Updates all five ONNX download URLs to the `onnx/english_2026-04/` bundle (mirroring the upstream `pocket-tts-web` repo layout change)
- Switches `mimi_encoder` / `text_conditioner` to the `_int8` variants now published in that bundle (INT8 builds of both exist; the "FP32 only" comment no longer holds)
- Adds `bos_before_voice.npy` (4,224 B) to the download set, per the bundle's `bundle.json` spec
- Bumps `NekoTtsService` init timeout 5s → 30s: first Pocket init is a cold ONNX session load (~12s observed), which the 5s timeout was already cutting short

All 15 URLs (5 INT8 ONNX + tokenizer + BOS + 8 voice wavs) were verified live (HTTP 200) before this commit. Tested on device: downloads complete past the previous 80% stall point and Pocket-TTS initializes and speaks.

## Notes for review

- The same `HF_BASE`/path updates are needed on `fix/all-github-issues` for the v1.5.0 line; the fix applies cleanly there as well (verified via cherry-pick onto that branch)
- Overlaps with #26 (which also fixes the base URL). This PR takes the *bundle-layout* path (`onnx/english_2026-04/*_int8.onnx`) matching the upstream repo's current tree, rather than alias-fallback — both approaches fix #24; maintainer preference welcome
- Related: #18 (BOS engine-side support for multilingual voices). This PR ships the BOS download; engine-side prepend logic can follow separately